### PR TITLE
update ODBC handling and expressions

### DIFF
--- a/skills/exivity-use/SKILL.md
+++ b/skills/exivity-use/SKILL.md
@@ -27,6 +27,19 @@ Use this skill to produce real USE scripts, not pseudocode. Favor complete extra
 - Prefer `clear http_headers` before setting a fresh header set for a different request.
 - Validate HTTP responses immediately after each request. If the task requires strict failure handling, terminate with error on non-success status.
 
+### Strict function and syntax rules
+
+- The **only** supported `@FUNCTION` calls are: `@MIN`, `@MAX`, `@ROUND`, `@CONCAT`, `@SUBSTR`, `@STRLEN`, `@PAD`, `@EXTRACT_BEFORE`, `@EXTRACT_AFTER`, `@CURDATE`, `@DATEADD`, `@DATEDIFF`, `@DTADD`, `@FILE_EXISTS`. **Never** use `@MATH` or any other function not in this list — they do not exist.
+- For arithmetic, use `var` expressions: `var x = (${x} + 2)` (integer and float) or operators: `var x += 10` (integer only, also `-=`, `*=`, `/=`, `%=`).
+- Variables use `${name}` syntax. Buffers use `{name}` syntax. These are **different namespaces** — never confuse them. The `.LENGTH` suffix only works on variables, not buffers.
+- `loop label [count] [timeout ms] { ... }` auto-creates `${label.COUNT}` — no manual counter needed.
+
+### ODBC limitations
+
+- A failed `buffer name = odbc_direct "query"` **immediately terminates the script**. There is no way to catch, trap, or recover from an ODBC failure in USE.
+- There is **no** `set odbc_retry_count` or `set odbc_retry_delay` — ODBC has no retry mechanism (unlike HTTP which has `set http_retry_count` / `set http_retry_delay`).
+- **Never** generate a retry/wait loop around `odbc_direct` — the fatal error kills the script before the loop can iterate. If the user asks for ODBC retry, explain the limitation and suggest retrying outside USE (PowerShell wrapper, Workflow scheduling, etc.).
+
 ## Preferred output patterns
 
 ### REST extractors

--- a/skills/exivity-use/references/use-patterns.md
+++ b/skills/exivity-use/references/use-patterns.md
@@ -17,6 +17,8 @@
 
 ## Error-handling pattern
 
+### HTTP errors
+
 Use this whenever the user asks for strict behavior:
 
 ```use
@@ -27,6 +29,19 @@ if (${HTTP_STATUS_CODE} !~ /200|202/) {
     terminate with error
 }
 ```
+
+HTTP supports built-in retry via `set http_retry_count` and `set http_retry_delay` (milliseconds). After all retries are exhausted, `${HTTP_STATUS_CODE}` is `-1` on transport failure — the script can still branch on this.
+
+### ODBC errors
+
+ODBC errors are **fatal and immediate** — a failed `buffer name = odbc_direct "query"` terminates the script with `S_ERROR`. There is:
+
+- No ODBC status variable (unlike `${HTTP_STATUS_CODE}` for HTTP).
+- No `set odbc_retry_count` or `set odbc_retry_delay`.
+- No way to catch the error inside a `loop` or `if` block.
+- No way to check whether a buffer was created after an ODBC call (the script is already dead).
+
+**Never** generate a retry loop around `odbc_direct` — it cannot work. If the user asks for ODBC retry, explain the limitation and suggest retrying outside the USE script (e.g. PowerShell wrapper, Exivity Workflow scheduling).
 
 ## Auth patterns to prefer
 

--- a/skills/exivity-use/references/use-syntax.md
+++ b/skills/exivity-use/references/use-syntax.md
@@ -57,6 +57,41 @@ This file distills the shared Exivity language reference into the parts that mos
 - Do not leave trailing spaces after encrypted plaintext values.
 - Encrypted values are machine-specific.
 
+## Supported functions
+
+- USE only supports the following `@FUNCTION(...)` calls: `@MIN`, `@MAX`, `@ROUND`, `@CONCAT`, `@SUBSTR`, `@STRLEN`, `@PAD`, `@EXTRACT_BEFORE`, `@EXTRACT_AFTER`, `@CURDATE`, `@DATEADD`, `@DATEDIFF`, `@DTADD`, `@FILE_EXISTS`.
+- There is **no** `@MATH` function. Arithmetic must be done via `var` expressions or operators:
+  - Expression form: `var x = (${x} + 2)` — supports integer and floating point.
+  - Operator form: `var x += 10` — integer only. Also `-=`, `*=`, `/=`, `%=`.
+
+## Variables vs buffers
+
+- Variables are referenced as `${name}`. The `.LENGTH` suffix (`${name.LENGTH}`) returns the string length and works **only on variables**.
+- Buffers are referenced as `{name}`. There is no `.LENGTH`, `.SIZE`, or `.EXISTS` suffix for buffers.
+- You **cannot** use `${buffername.LENGTH}` to check buffer size — that treats it as a variable, not a buffer, and will error with "Undefined variable" if the buffer name is not also a variable.
+
+## Loop statement
+
+- Syntax: `loop label [count] [timeout ms] { ... }`
+- The loop automatically creates `${label.COUNT}` (starts at 1, increments each iteration).
+- Use `exit_loop` to break out early.
+- Both `count` and `timeout` are optional; omitting both creates an infinite loop.
+
+## ODBC error handling
+
+- A failed `buffer name = odbc_direct "query"` immediately sets a fatal error status (`S_ERROR`) and **terminates the script**. There is no way to catch, trap, or recover from an ODBC failure within a USE script.
+- Unlike HTTP (which has `set http_retry_count` / `set http_retry_delay` for automatic retries), there is **no** `set odbc_retry_count` or `set odbc_retry_delay`. ODBC has no built-in retry mechanism.
+- When the ODBC call fails, the buffer is never created. Attempting to reference a non-existent buffer (via `match`, `save`, `discard`, etc.) also causes `S_ERROR`.
+- **Do not** attempt to wrap `odbc_direct` in a `loop` with `pause` for retry — the `S_ERROR` from the first failure kills the script before the loop can iterate.
+- If ODBC retry is needed, it must happen **outside** the USE script (e.g. via a PowerShell/batch wrapper that re-invokes the extractor, or via Workflow scheduling with multiple runs).
+
+## HTTP retry (built-in)
+
+- `set http_retry_count N` — number of retries after initial attempt (default: 1, so 2 total attempts).
+- `set http_retry_delay N` — delay in milliseconds between retries (default: 5000).
+- These only apply to HTTP requests, **not** to ODBC.
+- After HTTP failure you can still check `${HTTP_STATUS_CODE}` and branch — HTTP does not set `S_ERROR` on transport failure, it sets `${HTTP_STATUS_CODE}` to `-1`.
+
 ## Frequent failure modes
 
 - Attempting multiline statements with `\`.
@@ -64,3 +99,6 @@ This file distills the shared Exivity language reference into the parts that mos
 - Forgetting parentheses around functions in `var` assignments.
 - Comparing unquoted string variables inside `if` when values may contain parentheses.
 - Forgetting to handle `EXIVITY_NOT_FOUND` for optional JSON fields.
+- Using `@MATH` — this function does not exist. Use `var` arithmetic instead.
+- Trying to retry ODBC calls in a loop — `S_ERROR` is fatal and terminates the script immediately.
+- Confusing variable syntax `${x}` with buffer syntax `{x}` — they are different namespaces.


### PR DESCRIPTION
- "Strict function and syntax rules" section (allowed @FUNCTION whitelist, @MATH prohibition, arithmetic syntax, variable vs buffer distinction) and "ODBC limitations" section (fatal errors, no retry, never generate retry loops)
- "Supported functions", "Variables vs buffers", "Loop statement", "ODBC error handling", "HTTP retry (built-in)" sections, plus expanded "Frequent failure modes" with @MATH, ODBC retry, and ${x} vs {x} pitfalls
- Split error-handling into "HTTP errors" and "ODBC errors" subsections with clear guidance to never generate ODBC retry loops