### PR TITLE
skills: add ETL authoring lessons from Nutanix template build

### DIFF
--- a/skills/exivity-transcript/SKILL.md
+++ b/skills/exivity-transcript/SKILL.md
@@ -26,6 +26,12 @@ Use this skill to produce real Transcript transformer scripts, not generic ETL p
 - When using `aggregate`, remember that Transcript automatically creates `EXIVITY_AGGR_COUNT`.
 - Keep `where` blocks limited to statements Transcript actually permits there.
 - Choose `finish` when the user wants RDF/report output, and `export` when they want an intermediate CSV or JSON file.
+- With `pattern enabled` imports, regex matching applies to the filename portion; keep directory parts literal (for example use `${dataYear}/${dataMonth}` in the path).
+- Avoid deriving `hour` from `EXIVITY_FILE_NAME` using nested underscore extraction; this is brittle when host/file segments include underscores. Prefer hourly-file import + aggregate logic, or a dedicated `hour` column from the extractor.
+- **Column-to-column copy uses `set <target> as <source>`**, not `set <target> to [<source>]`. The bracketed form is treated as a literal token, not a column reference. Use `set cluster_name as cluster_uuid`, not `set cluster_name to [cluster_uuid]`.
+- **When a downstream dset needs an additional field from a lookup, update three places consistently**: (1) extend the `correlate` field list to pull the new field, (2) add `match <field>` to any subsequent `aggregate` so the field survives reduction, (3) remove any `create column <field>` that would otherwise reset it to empty.
+- **The `services {}` block must reference the FINAL (post-rename, post-lowercase) column names.** After lowercasing operational columns or renaming `Usage` → `quantity`, update `consumption_col`, `unit_label_col`, `category_col`, etc. accordingly. Mismatched names cause silent service-build failures.
+- **Provide fallbacks for empty enrichment columns** (e.g. when a vendor API does not return a friendly name). After aggregate, use `where ([col] == "") { set col as <fallback_col> }` and `where ([col] == "EXIVITY_NOT_FOUND") { set col as <fallback_col> }` to ensure the field is always populated.
 
 ## Preferred transformer workflow
 

--- a/skills/exivity-transcript/references/transcript-syntax.md
+++ b/skills/exivity-transcript/references/transcript-syntax.md
@@ -38,6 +38,26 @@ This file distills the shared Exivity language reference into the parts that mos
 - `export`
 - `finish`
 
+### `set` value sources
+
+- Literal string: `set col to "value"`
+- Variable: `set col to "${var}"`
+- **Another column (column-to-column copy): `set col as other_col`** (no brackets).
+- `set col to [other_col]` is **wrong** — it stores the literal text `[other_col]` instead of copying the column value.
+
+## Import patterns with `pattern enabled`
+
+- Regex matching applies only to the **filename portion** of the import path.
+- The **directory portion must be literal** — built from `${dataYear}`, `${dataMonth}`, etc.
+- Example:
+  ```trs
+  var dir = "system/extracted/MySource/${dataYear}/${dataMonth}"
+  import "${dir}/${dataDate}_[^_]+_MySource\\.csv" source mysrc alias data options {
+      pattern enabled
+  }
+  ```
+- Operator-supplied identifiers used in regex-matched filename segments (e.g. host alias matched by `[^_]+`) must not contain the regex separator character (typically underscore).
+
 ## Aggregate behavior
 
 - `aggregate` reduces rows while preserving information according to chosen functions.
@@ -50,6 +70,22 @@ This file distills the shared Exivity language reference into the parts that mos
 - A common cleanup step is:
   - correlate with `default EXIVITY_NOT_FOUND`
   - replace or set friendlier fallback values in a later `where` block.
+- **When extending a `correlate` with a new field, propagate the change**:
+  1. Add the field to the `correlate` field list.
+  2. Add `match <field>` to every subsequent `aggregate` on that dset.
+  3. Remove any later `create column <field>` that would reset it to empty.
+- **Fallback to a related column when enrichment is empty**:
+  ```trs
+  where ([cluster_name] == "") { set cluster_name as cluster_uuid }
+  where ([cluster_name] == "EXIVITY_NOT_FOUND") { set cluster_name as cluster_uuid }
+  ```
+
+## Services block
+
+- The `services {}` block at the end of the transformer must reference the **final** column names — i.e. names after all `rename`, lowercase, or post-aggregate adjustments.
+- When renaming `Usage` → `quantity`, also update `consumption_col = quantity`.
+- When lowercasing operational columns, also update `unit_label_col`, `category_col`, `set_rate_using`, `set_cogs_using`, etc.
+- A mismatched name here typically produces no error but no services either.
 
 ## Where-block limits
 
@@ -73,3 +109,9 @@ Inside `where`, keep to supported statements such as:
 - Using unsupported statements inside a `where` block.
 - Mixing up `${variable}` syntax and `[ColumnName]` syntax.
 - Forgetting to handle missing correlations.
+- **Treating import paths as regex.** With `pattern enabled`, only the filename portion is regex-matched — the directory portion must be a literal path. Build it from `${dataYear}` / `${dataMonth}` etc.
+- **Parsing hour/date from `EXIVITY_FILE_NAME`** with nested `@EXTRACT_AFTER` / `@EXTRACT_BEFORE` on underscores. This breaks as soon as another filename segment contains an underscore. Use hourly-stamped imports + aggregation instead, or have the extractor emit an explicit `hour` column.
+- **`set col to [other_col]`** — this stores the literal string `[other_col]`, not the column value. The correct form for column-to-column copy is `set col as other_col`.
+- **Extending a lookup without updating downstream aggregate.** If you add a field to a `correlate`, every later `aggregate` on that dset must include `match <field>`, otherwise the field is dropped.
+- **`services {}` referencing pre-rename column names.** After renaming `Usage` → `quantity` or lowercasing columns, the `services` block's `consumption_col`, `unit_label_col`, `category_col` etc. must point at the new names.
+- **Forcing an enriched column blank with a late `create column`** after a `correlate` already populated it.

--- a/skills/exivity-use/SKILL.md
+++ b/skills/exivity-use/SKILL.md
@@ -22,10 +22,14 @@ Use this skill to produce real USE scripts, not pseudocode. Favor complete extra
 - In `if` expressions, quote string-valued variables when special characters may appear: `if ("${name}" == "")`.
 - For `match`, always include at least one capture group in the regex.
 - Treat missing JSON paths as `EXIVITY_NOT_FOUND` and handle optional fields explicitly.
+- **Optional JSON arrays must be probed before `foreach`.** A `foreach` over a missing path raises a fatal "JSON path becomes invalid" error and halts the script — it does **not** silently iterate zero times. Read the path into a `var` first and only enter the `foreach` when it is not `EXIVITY_NOT_FOUND`.
 - Use `public var` for operator-editable settings and `public encrypt var` for secrets that should appear in the GUI.
+- **Prefer plain `public var` for secrets sourced from environment variables.** `public encrypt var` can corrupt externally-supplied secrets in some Exivity installs (the value gets re-encrypted machine-specifically and the wire value becomes unusable). When the secret comes from a `${ENV_VAR}` reference, default to `public var` unless the operator explicitly wants GUI-encrypted storage.
 - Remember that `encrypt` and `encrypted` are preprocessor directives and encrypted values are machine-specific.
 - Prefer `clear http_headers` before setting a fresh header set for a different request.
 - Validate HTTP responses immediately after each request. If the task requires strict failure handling, terminate with error on non-success status.
+- **`set http_retry_count` / `set http_retry_delay` only retry on transport failure (`${HTTP_STATUS_CODE} == -1`), NOT on application-level statuses like 429 / 500 / 503.** To handle rate limiting or server errors, hand-roll a retry loop around the request and branch on `${HTTP_STATUS_CODE}` explicitly. Expose retry knobs as `public var` (e.g. `retry_count`, `retry_delay_ms`) so operators can tune.
+- **Expose operationally-tunable HTTP behavior as `public var`**: page size, retry count, retry delay, timeouts, granularity (`daily`/`hourly`), and any optional inclusion switches. Hard-coded values force script edits for routine tuning.
 
 ### Strict function and syntax rules
 

--- a/skills/exivity-use/references/use-syntax.md
+++ b/skills/exivity-use/references/use-syntax.md
@@ -24,7 +24,16 @@ This file distills the shared Exivity language reference into the parts that mos
 - Direct access: `$JSON{buffer}.[field]`
 - Nested access: `$JSON{buffer}.[a].[b]`
 - Iterator access inside foreach: `$JSON(item).[field]`
-- Missing paths return `EXIVITY_NOT_FOUND`.
+- Missing paths return `EXIVITY_NOT_FOUND` **for scalar reads only**.
+- **For `foreach`, a missing array path is fatal.** A `foreach $JSON(item).[maybe_missing]` over a path that does not exist raises "JSON path becomes invalid" and halts the script. Always probe optional arrays first:
+  ```use
+  var probe = $JSON(item).[maybe_missing]
+  if ("${probe}" != "EXIVITY_NOT_FOUND") {
+      foreach $JSON(item).[maybe_missing] as child {
+          # ...
+      }
+  }
+  ```
 
 ## Looping
 
@@ -56,6 +65,7 @@ This file distills the shared Exivity language reference into the parts that mos
 - The encrypted value extends from the first non-whitespace character after `=` to end of line.
 - Do not leave trailing spaces after encrypted plaintext values.
 - Encrypted values are machine-specific.
+- **Prefer plain `public var` for secrets sourced from environment variables / external secret stores.** `public encrypt var` re-encrypts the value machine-specifically; in some installs the resulting wire value is corrupted and authentication fails. When the value comes from `${ENV_VAR}` or another externally-managed source, use `public var` unless the operator explicitly asks for GUI-encrypted storage.
 
 ## Supported functions
 
@@ -90,7 +100,29 @@ This file distills the shared Exivity language reference into the parts that mos
 - `set http_retry_count N` — number of retries after initial attempt (default: 1, so 2 total attempts).
 - `set http_retry_delay N` — delay in milliseconds between retries (default: 5000).
 - These only apply to HTTP requests, **not** to ODBC.
-- After HTTP failure you can still check `${HTTP_STATUS_CODE}` and branch — HTTP does not set `S_ERROR` on transport failure, it sets `${HTTP_STATUS_CODE}` to `-1`.
+- **Built-in retry only fires on transport failure (`${HTTP_STATUS_CODE} == -1`).** Application-level statuses like `429` (rate limited), `500`, `502`, `503`, `504` are returned to the script as successful HTTP exchanges and the built-in retry does **not** trigger.
+- For rate-limit or server-error retry, hand-roll a retry loop and branch on `${HTTP_STATUS_CODE}`:
+  ```use
+  public var retry_count = "5"
+  public var retry_delay_ms = "2000"
+
+  var attempts = (${retry_count}+1)
+  var ok = 0
+  loop try "${attempts}" {
+      buffer resp = http GET "${url}"
+      if (${HTTP_STATUS_CODE} == 200) {
+          var ok = 1
+          exit_loop
+      }
+      if (${HTTP_STATUS_CODE} != 429) {
+          exit_loop
+      }
+      if (${try.COUNT} < ${attempts}) {
+          pause ${retry_delay_ms}
+      }
+  }
+  ```
+- Expose retry knobs (`retry_count`, `retry_delay_ms`) as `public var` so operators can tune without editing the script.
 
 ## Frequent failure modes
 
@@ -99,6 +131,10 @@ This file distills the shared Exivity language reference into the parts that mos
 - Forgetting parentheses around functions in `var` assignments.
 - Comparing unquoted string variables inside `if` when values may contain parentheses.
 - Forgetting to handle `EXIVITY_NOT_FOUND` for optional JSON fields.
+- **`foreach` over a missing JSON array path** — this is fatal, not a no-op. Always probe optional arrays first.
 - Using `@MATH` — this function does not exist. Use `var` arithmetic instead.
 - Trying to retry ODBC calls in a loop — `S_ERROR` is fatal and terminates the script immediately.
 - Confusing variable syntax `${x}` with buffer syntax `{x}` — they are different namespaces.
+- **Relying on `set http_retry_count` to handle HTTP 429/500** — built-in retry only fires on transport failure (`-1`). Application-level statuses need a hand-rolled loop.
+- **Using `public encrypt var` for env-sourced secrets** — re-encryption is machine-specific and can corrupt externally-managed secret values. Prefer plain `public var`.
+- Hard-coding tunable values (page size, retry count, granularity, timeouts) instead of exposing them as `public var`.


### PR DESCRIPTION
## Summary

Adds guidance to both Exivity skills based on issues encountered while building the Nutanix Prism Central v4 template set. All changes are pure additions — no existing canonical content is rewritten or removed.

## exivity-use

- `foreach` over a missing JSON array is **fatal**, not a no-op — must probe the path into a `var` first and gate the loop on `EXIVITY_NOT_FOUND`.
- `public encrypt var` can corrupt env-sourced secrets (re-encryption is machine-specific); prefer plain `public var` for secrets supplied via `${ENV_VAR}`.
- `set http_retry_count` / `set http_retry_delay` only retry on transport failure (`${HTTP_STATUS_CODE} == -1`), **not** on application statuses like 429/500/503. Documents a hand-rolled retry loop pattern with `public var retry_count` / `retry_delay_ms`.
- Operationally-tunable values (page size, retries, granularity, include switches) should be exposed as `public var`.

## exivity-transcript

- Column-to-column copy is `set col as other_col`, **not** `set col to [other_col]` (the bracket form stores the literal token).
- When extending a `correlate` with a new field, propagate to every downstream `aggregate ... match` and remove any later `create column` that would reset it.
- The `services {}` block must reference **final** column names (post-rename, post-lowercase). E.g. after `Usage` → `quantity`, `consumption_col = quantity`.
- Fallback pattern for empty enrichment columns: `where ([col] == "") { set col as fallback_col }`.
- With `pattern enabled` imports, the **directory portion must be literal**; regex matching applies only to the filename.
- Avoid deriving `hour` from `EXIVITY_FILE_NAME` via nested underscore extraction (brittle when host segments contain underscores).

## Origin

These rules came out of debugging the Nutanix Prism Central v4 template against a live PC instance. Every item maps to a concrete failure mode the AI agent would otherwise re-introduce.

## Files

- `skills/exivity-use/SKILL.md` (+4)
- `skills/exivity-use/references/use-syntax.md` (+38 / -2)
- `skills/exivity-transcript/SKILL.md` (+6)
- `skills/exivity-transcript/references/transcript-syntax.md` (+42)
